### PR TITLE
Fix typo in the streaming example.

### DIFF
--- a/examples/src/streaming/server.rs
+++ b/examples/src/streaming/server.rs
@@ -44,7 +44,7 @@ impl pb::echo_server::Echo for EchoServer {
             type Item = Result<EchoResponse, Status>;
 
             fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-                // A stream that never resovlves to anything....
+                // A stream that never resolves to anything....
                 Poll::Pending
             }
         }


### PR DESCRIPTION
## Motivation

Typo in one of the comments from the streaming example.

https://github.com/hyperium/tonic/blob/master/examples/src/streaming/server.rs#L47

## Solution

Fixed typo.